### PR TITLE
fix print statements

### DIFF
--- a/count.py
+++ b/count.py
@@ -23,5 +23,9 @@ time.sleep(num_seconds_sleep)
 s = [x.lower() for x in s if x.isalpha()]
 
 # print result
-for (character, count) in Counter(s).most_common(10):
-    print(character, count)
+for character, count in Counter(s).most_common(10):
+    print(character + " " + str(count))
+try:
+    sys.stdout.flush()
+except IOError:
+    pass

--- a/plot.py
+++ b/plot.py
@@ -19,4 +19,4 @@ for line in sys.stdin.readlines():
     s = line.split()
     character = s[0]
     count = int(s[1])//2
-    print(character, '#'*count)
+    print(character + " " +"#"*count)


### PR DESCRIPTION
The print statements erroneously print "('a', 9)" when they should print "a 9" etc. which then breaks plot.py etc.

Also there was an interesting bug in closing stdout when piping python scripts on OS X that is fixed by flushing.